### PR TITLE
fix TLD of setup url arg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     long_description=README,
     author='Robin van der Rijst - Fabrique',
     author_email='robinr@fabrique.nl',
-    url='https://github.org/fabrique/wagtail-easy-thumbnails',
+    url='https://github.com/fabrique/wagtail-easy-thumbnails',
     install_requires=[
             'wagtail>=1.5',
             'easy_thumbnails>=2.3',


### PR DESCRIPTION
s/github.org/github.com/

It's a tiny fix so you may just want to roll it up into the next time you touch on setup, but since it breaks the link to the code from PyPI I thought I'd let you know anyway.

Thanks for sharing your code!