### PR TITLE
Fix float division by zero error.

### DIFF
--- a/wagtail_easy_thumbnails/processors.py
+++ b/wagtail_easy_thumbnails/processors.py
@@ -71,7 +71,7 @@ def wagtail_scale_and_crop_with_focal_area(im, size, crop=False, focal_area=None
     zoom_100_height = round(max(focal_width / target_ratio, focal_width / focal_ratio))
 
     max_zoom_ratio = 1
-    if zoom_100_width > zoom_0_width or zoom_100_height > zoom_0_height:
+    if zoom_100_width >= zoom_0_width or zoom_100_height >= zoom_0_height:
         # make sure full zoom is never larger than no zoom
         max_zoom_ratio = 0
     elif zoom_100_width < target_width or zoom_100_height < target_height:


### PR DESCRIPTION
 For the case that focal width or height is image width or height, it would seem that zooming is not possible. Not sure if it matters then whether zoom_ratio is 0 or 1. Currently I went with 0, although 1 is possible as well.